### PR TITLE
auth0 iOS sample - Return JWT instead of Auth0 access code

### DIFF
--- a/docs/chapter2/custom.md
+++ b/docs/chapter2/custom.md
@@ -611,7 +611,7 @@ For our iOS application, we are going to integrate Auth0 into the `Services\iOSL
                 "shellmonger.auth0.com",
                 "lmFp5jXnwPpD9lQIYwgwwPmFeofuLpYq");
             var user = await auth0.LoginAsync(RootView, scope: "openid email");
-            return user.Auth0AccessToken;
+            return user.IdToken;
         }
 ```
 


### PR DESCRIPTION
Small change to the documentation of Chapter 2 to reflect the code samples. The documentation is returning Auth0Access token when it should be returning IdToken which is the actual JWT which Mobile Apps is expecting.