### PR TITLE
Fixed issue with SQL insert/delete triggers causing only one record t…

### DIFF
--- a/docs/chapter3/server.md
+++ b/docs/chapter3/server.md
@@ -506,10 +506,9 @@ ON
 AFTER
     INSERT
 AS BEGIN
-    DECLARE @itemid AS BIGINT
-    SELECT @itemid = inserted.id FROM inserted
     INSERT INTO [mobile].[SysProps_TodoItems] ([Item_Id], [UpdatedAt])
-        VALUES (@itemid, CONVERT(DATETIMEOFFSET(7), SYSUTCDATETIME()));
+	SELECT inserted.id, CONVERT(DATETIMEOFFSET(7), SYSUTCDATETIME())
+	FROM inserted
 END
 GO
 
@@ -538,9 +537,8 @@ ON
 AFTER
     DELETE
 AS BEGIN
-    DECLARE @itemid AS BIGINT
-    SELECT @itemid = deleted.id from deleted
-    DELETE FROM [mobile].[SysProps_TodoItems] WHERE [Item_Id] = @itemid
+    DELETE FROM [mobile].[SysProps_TodoItems] 
+	WHERE [Item_Id] IN (select deleted.id from deleted)
 END
 GO
 ```


### PR DESCRIPTION
Fixed issue with SQL insert/delete triggers causing only one record to be affected on a mass insert/delete.

This is in the section for adapting an existing sql database to use the azure cloud columns.
If the existing application has a function that allows for inserting/deleting on more than one TodoItem record at a time, the trigger will only affect one SysProps_TodoItem record.

The new trigger code will allow insert/delete on multiple records at a time.
